### PR TITLE
🔀 :: [#242] PrivacyManifest 추가

### DIFF
--- a/.github/workflows/CachingTuistDependencies.yml
+++ b/.github/workflows/CachingTuistDependencies.yml
@@ -12,9 +12,10 @@ env:
 jobs:
   caching-dependencies:
     name: 🧩 Caching Dependencies
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v2
+      - uses: jdx/mise-action@v2
 
       - name: Compute dependency cache key
         id: compute_hash
@@ -29,11 +30,11 @@ jobs:
 
       - name: Install tuist
         if: steps.cache_dependencies.outputs.cache-hit != 'true'
-        run: curl -Ls https://install.tuist.io | bash
+        run: mise install tuist
 
       - name: Install dependencies
         if: steps.cache_dependencies.outputs.cache-hit != 'true'
-        run: tuist fetch
+        run: tuist install
 
     outputs:
       dependency_cache_key: ${{ steps.compute_hash.outputs.hash }}

--- a/Projects/App/Resources/PrivacyInfo.xcprivacy
+++ b/Projects/App/Resources/PrivacyInfo.xcprivacy
@@ -60,6 +60,14 @@
 		<dict>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
+				<string>35F9.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
 				<string>3B52.1</string>
 				<string>C617.1</string>
 				<string>DDA9.1</string>

--- a/Projects/App/Resources/PrivacyInfo.xcprivacy
+++ b/Projects/App/Resources/PrivacyInfo.xcprivacy
@@ -6,6 +6,20 @@
 	<array>
 		<dict>
 			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherUsageData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeProductPersonalization</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
 			<string>NSPrivacyCollectedDataTypePhotosorVideos</string>
 			<key>NSPrivacyCollectedDataTypeLinked</key>
 			<false/>
@@ -43,10 +57,29 @@
 	</array>
 	<key>NSPrivacyAccessedAPITypes</key>
 	<array>
-		<dict/>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>3B52.1</string>
+				<string>C617.1</string>
+				<string>DDA9.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
 	</array>
 	<key>NSPrivacyTrackingDomains</key>
-	<array/>
+	<array>
+		<string>https://open.neis.go.kr</string>
+	</array>
 	<key>NSPrivacyTracking</key>
 	<false/>
 </dict>

--- a/Projects/App/Resources/PrivacyInfo.xcprivacy
+++ b/Projects/App/Resources/PrivacyInfo.xcprivacy
@@ -78,6 +78,7 @@
 	</array>
 	<key>NSPrivacyTrackingDomains</key>
 	<array>
+		<string>https://server-v2.dotori-gsm.com/v2</string>
 		<string>https://open.neis.go.kr</string>
 	</array>
 	<key>NSPrivacyTracking</key>

--- a/Projects/App/Support/PrivacyInfo.xcprivacy
+++ b/Projects/App/Support/PrivacyInfo.xcprivacy
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypePhotosorVideos</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeEmailAddress</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeName</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict/>
+	</array>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>


### PR DESCRIPTION
## 💡 개요
애플의 개인정보 보호정책 변경으로 인해 PrivacyManifest에 Required Reason API를 사용한 이유를 설명하지 않는 앱을 허용하지 않는다고 해서 PrivacyManifest 파일을 추가합니다.

## 📃 작업내용
Privacy Nutrition Label Types에 유저 이름, 이메일, 사용자 사진 및 비디오 사용자 활동 기록을 추가했어요.
Privacy Accessed API Types에 파일 타임 스탬프, UserDefaults를 추가했어요.
NSPrivacyTrackingDomains에 나이스를 추가했어요.

## 🎸 기타
부족한 부분 있는지 한 번씩 확인해주세요!!